### PR TITLE
Expose projects-related fields in `GHOrganization`

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -2,7 +2,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>com.progressor</groupId>
   <artifactId>github-api</artifactId>
-  <version>1.129-SNAPSHOT</version>
+  <version>1.130-SNAPSHOT</version>
   <name>GitHub API for Java</name>
   <url>https://github-api.kohsuke.org/</url>
   <description>GitHub API for Java</description>

--- a/src/build/eclipse/formatter.xml
+++ b/src/build/eclipse/formatter.xml
@@ -17,6 +17,8 @@
         <setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_brace_in_array_initializer" value="insert"/>
         <setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_brace_in_array_initializer" value="insert"/>
         <setting id="org.eclipse.jdt.core.formatter.tabulation.char" value="space"/>
+        <setting id="org.eclipse.jdt.core.formatter.comment.format_javadoc_comments" value="false"/>
+        <setting id="org.eclipse.jdt.core.formatter.comment.format_block_comments" value="false"/>
     </profile>
     <!-- Keeping the "default" exported values for reference -->
     <!--

--- a/src/main/java/org/kohsuke/github/GHOrganization.java
+++ b/src/main/java/org/kohsuke/github/GHOrganization.java
@@ -20,6 +20,11 @@ import static org.kohsuke.github.internal.Previews.INERTIA;
 @SuppressWarnings({ "UnusedDeclaration" })
 public class GHOrganization extends GHPerson {
 
+    /*
+    The fields below are named in Snake case intentionally. Instances of this class
+    are parsed from JSON via databinding. Field names should strictly map to JSON fields.
+     */
+
     private boolean has_organization_projects;
     private boolean has_repository_projects;
 

--- a/src/main/java/org/kohsuke/github/GHOrganization.java
+++ b/src/main/java/org/kohsuke/github/GHOrganization.java
@@ -17,7 +17,12 @@ import static org.kohsuke.github.internal.Previews.INERTIA;
  *
  * @author Kohsuke Kawaguchi
  */
+@SuppressWarnings({ "UnusedDeclaration" })
 public class GHOrganization extends GHPerson {
+
+    private boolean has_organization_projects;
+    private boolean has_repository_projects;
+
     GHOrganization wrapUp(GitHub root) {
         return (GHOrganization) super.wrapUp(root);
     }
@@ -268,6 +273,28 @@ public class GHOrganization extends GHPerson {
         } catch (IOException ignore) {
             return false;
         }
+    }
+
+    /**
+     * Returns {@code true} if this organization has `Projects` feature enabled.
+     *
+     * <p>
+     * This flag doesn't guarantee the actual presence of any projects. It just says whether this functionality
+     * is enabled at all.
+     */
+    public boolean hasOrganizationProjects() {
+        return has_organization_projects;
+    }
+
+    /**
+     * Returns {@code true} if this organization has at least one repository with `Projects` feature enabled.
+     *
+     * <p>
+     * This flag doesn't guarantee the actual presence of any projects. It just says whether this functionality
+     * is enabled for at least a single repository in the organization.
+     */
+    public boolean hasRepositoryProjects() {
+        return has_repository_projects;
     }
 
     /**
@@ -536,7 +563,7 @@ public class GHOrganization extends GHPerson {
      *             the io exception
      */
     public List<GHRepository> getRepositoriesWithOpenPullRequests() throws IOException {
-        List<GHRepository> r = new ArrayList<GHRepository>();
+        List<GHRepository> r = new ArrayList<>();
         for (GHRepository repository : listRepositories(100)) {
             repository.wrap(root);
             List<GHPullRequest> pullRequests = repository.getPullRequests(GHIssueState.OPEN);

--- a/src/main/java/org/kohsuke/github/GHOrganization.java
+++ b/src/main/java/org/kohsuke/github/GHOrganization.java
@@ -276,22 +276,22 @@ public class GHOrganization extends GHPerson {
     }
 
     /**
-     * Returns {@code true} if this organization has `Projects` feature enabled.
+     * Returns {@code true} if this organization can use projects.
      *
      * <p>
-     * This flag doesn't guarantee the actual presence of any projects. It just says whether this functionality
-     * is enabled at all.
+     * This flag doesn't guarantee the actual presence of any projects.
+     * It just says whether this functionality is enabled at all.
      */
     public boolean hasOrganizationProjects() {
         return has_organization_projects;
     }
 
     /**
-     * Returns {@code true} if this organization has at least one repository with `Projects` feature enabled.
+     * Returns {@code true} if projects that belong to the organization can use projects.
      *
      * <p>
-     * This flag doesn't guarantee the actual presence of any projects. It just says whether this functionality
-     * is enabled for at least a single repository in the organization.
+     * This flag doesn't guarantee the actual presence of any projects. It just says
+     * whether this functionality is enabled at all.
      */
     public boolean hasRepositoryProjects() {
         return has_repository_projects;

--- a/src/main/java/org/kohsuke/github/GHOrganization.java
+++ b/src/main/java/org/kohsuke/github/GHOrganization.java
@@ -283,8 +283,7 @@ public class GHOrganization extends GHPerson {
     /**
      * Returns {@code true} if this organization can use projects.
      *
-     * <p>
-     * This flag doesn't guarantee the actual presence of any projects.
+     * <p> This flag doesn't guarantee the actual presence of any projects.
      * It just says whether this functionality is enabled at all.
      */
     public boolean hasOrganizationProjects() {
@@ -294,8 +293,7 @@ public class GHOrganization extends GHPerson {
     /**
      * Returns {@code true} if repositories that belong to the organization can use projects.
      *
-     * <p>
-     * This flag doesn't guarantee the actual presence of any projects. It just says
+     * <p> This flag doesn't guarantee the actual presence of any projects. It just says
      * whether this functionality is enabled at all.
      */
     public boolean hasRepositoryProjects() {

--- a/src/main/java/org/kohsuke/github/GHOrganization.java
+++ b/src/main/java/org/kohsuke/github/GHOrganization.java
@@ -287,7 +287,7 @@ public class GHOrganization extends GHPerson {
     }
 
     /**
-     * Returns {@code true} if projects that belong to the organization can use projects.
+     * Returns {@code true} if repositories that belong to the organization can use projects.
      *
      * <p>
      * This flag doesn't guarantee the actual presence of any projects. It just says


### PR DESCRIPTION
This PR exposes two fields in `GHOrganization`.

GitHub started to fail the request to list organization or repository projects if this feature is not enabled at all.  Thus, it is better to check if this feature is enabled before sending an actual request. 

`GHRepository` has this field already exposed, so we need to expose the corresponding fields for organizations as well:

1) `has_organization_projects` – tells whether an organization can use projects.
2) `has_repository_projects` – tells whether repositories that belong to the organization can use projects.

Instances of `GHOrganization` are parsed from JSON, thus we don't need to fulfill these fields manually.

The library version is bumped to `1.130-SNAPSHOT`.